### PR TITLE
Mission Center: align Crypto Trader view with state.json + closed_trade schema

### DIFF
--- a/docs/trader-files.md
+++ b/docs/trader-files.md
@@ -43,23 +43,28 @@ Fields used by Mission Center:
 
 - `mode` (`paper` or `live`)
 - `portfolio.equity_usd` and `portfolio.cash_usd`
-- `portfolio.positions` and/or `open_positions`
-- `open_orders` and/or `openOrdersCount`
+- `portfolio.positions` + `portfolio.open_meta` (for entry/mark/unrealized)
+- `open_orders` (count + a small allowlisted summary)
+- `risk` (cooldown/drawdown flags and day pnl)
+- `strategy_params` (current strategy parameters)
+- `ai_strategist` (enabled/provider/model + last run info)
 - `products` and `prices`
 - `ts` (fallback to file modified time if missing)
 
 ## trades.jsonl schema
 
-`trades.jsonl` is JSONL (one JSON object per line). Mission Center reads the newest lines from the end of file and extracts:
+`trades.jsonl` is JSONL (one JSON object per line). Mission Center reads the newest lines from the end of file and extracts **closed trades**:
 
-- `ts` (or `timestamp` / `time`)
-- `product` (or `symbol`)
-- `side`
-- `qty`
-- `price`
-- `fees`
-- `pnlUsd`
+- `type` must be `"closed_trade"` (if present)
+- `id`
+- `product`
+- `qty_base`
+- `entry_price`, `exit_price`
+- `pnl_usd`, `pnl_pct`
+- `open_ts`, `close_ts`
 - `reason` (best-effort)
+
+Rows are returned **newest-first**.
 
 Malformed lines are skipped.
 

--- a/lib/trader.ts
+++ b/lib/trader.ts
@@ -26,14 +26,44 @@ export type TraderOpenPosition = {
   unrealizedPnlUsd?: number
 }
 
+export type TraderRiskSnapshot = {
+  drawdownHalt?: boolean
+  cooldownActive?: boolean
+  drawdownPct?: number
+  maxDrawdownSeenPct?: number
+  lossStreak?: number
+  dayId?: string
+  dayRealizedPnlUsd?: number
+  dayStartEquityUsd?: number
+  updatedTs?: string | null
+}
+
+export type TraderStrategyParamsSnapshot = {
+  [key: string]: string | number | boolean | null
+}
+
+export type TraderAiStrategistSnapshot = {
+  enabled: boolean
+  provider: string | null
+  model: string | null
+  state: {
+    lastRunTs: string | null
+    lastChange: string | null
+  }
+}
+
 export type TraderTradeRow = {
-  ts: string | null
+  id: string | null
+  type: 'closed_trade'
   product: string
   side: string | null
-  qty: number | null
-  price: number | null
-  fees: number | null
+  qtyBase: number | null
+  entryPrice: number | null
+  exitPrice: number | null
   pnlUsd: number | null
+  pnlPct: number | null
+  openTs: string | null
+  closeTs: string | null
   reason: string | null
 }
 
@@ -43,6 +73,10 @@ export type TraderStatusSnapshot = {
   cashUsd: number | null
   openPositions: TraderOpenPosition[]
   openOrdersCount: number
+  openOrders: Array<{ id: string | null; product: string | null; side: string | null; qtyBase: number | null; status: string | null }>
+  risk: TraderRiskSnapshot
+  strategyParams: TraderStrategyParamsSnapshot
+  aiStrategist: TraderAiStrategistSnapshot
   products: string[]
   lastRunTs: string | null
   lastError: string | null
@@ -269,7 +303,15 @@ function extractLastErrorFromText(text: string): string | null {
 }
 
 function parseTradeTimestamp(raw: any): string | null {
-  return toIsoTimestamp(raw?.ts ?? raw?.timestamp ?? raw?.time ?? raw?.filled_at ?? raw?.filledAt)
+  return toIsoTimestamp(
+    raw?.close_ts ??
+      raw?.closeTs ??
+      raw?.ts ??
+      raw?.timestamp ??
+      raw?.time ??
+      raw?.filled_at ??
+      raw?.filledAt,
+  )
 }
 
 function normalizeTradeSide(raw: any): string | null {
@@ -334,12 +376,22 @@ export function readTraderStatusSnapshot(): TraderStatusSnapshot {
   const mode = toSafeMode(state?.mode ?? state?.tradingMode ?? state?.portfolio?.mode)
   const equityUsd = pickFirstNumber(state?.equityUsd, state?.equity_usd, state?.portfolio?.equityUsd, state?.portfolio?.equity_usd)
   const cashUsd = pickFirstNumber(state?.cashUsd, state?.cash_usd, state?.portfolio?.cashUsd, state?.portfolio?.cash_usd)
-  const openOrdersCount = Math.max(
-    0,
-    Math.floor(
-      pickFirstNumber(state?.openOrdersCount, state?.open_orders_count, state?.openOrders?.length, state?.open_orders?.length, 0) || 0,
-    ),
-  )
+
+  const rawOpenOrders = Array.isArray(state?.open_orders)
+    ? state.open_orders
+    : Array.isArray(state?.openOrders)
+      ? state.openOrders
+      : []
+
+  const openOrdersCount = Math.max(0, Math.floor(pickFirstNumber(state?.openOrdersCount, state?.open_orders_count, rawOpenOrders.length, 0) || 0))
+
+  const openOrders = rawOpenOrders.slice(0, 40).map((o: any) => ({
+    id: pickFirstString(o?.id, o?.order_id),
+    product: sanitizeProduct(o?.product),
+    side: normalizeTradeSide(o),
+    qtyBase: pickFirstNumber(o?.qty_base, o?.qty, o?.quantity, o?.size),
+    status: pickFirstString(o?.status, o?.state),
+  }))
 
   const products = Array.isArray(state?.products)
     ? state.products.map((p: unknown) => sanitizeProduct(p)).filter((p: string | null): p is string => Boolean(p))
@@ -353,6 +405,39 @@ export function readTraderStatusSnapshot(): TraderStatusSnapshot {
       const safe = sanitizeProduct(key)
       if (safe) inferredProducts.add(safe)
     }
+  }
+
+  const risk = state?.risk && typeof state.risk === 'object' ? state.risk : {}
+  const riskSnapshot: TraderRiskSnapshot = {
+    drawdownHalt: Boolean(risk?.drawdown_halt),
+    cooldownActive: Boolean(risk?.cooldown_active),
+    drawdownPct: asFiniteNumber(risk?.drawdown_pct) ?? undefined,
+    maxDrawdownSeenPct: asFiniteNumber(risk?.max_drawdown_seen_pct) ?? undefined,
+    lossStreak: asFiniteNumber(risk?.loss_streak) ?? undefined,
+    dayId: pickFirstString(risk?.day_id) || undefined,
+    dayRealizedPnlUsd: asFiniteNumber(risk?.day_realized_pnl_usd) ?? undefined,
+    dayStartEquityUsd: asFiniteNumber(risk?.day_start_equity_usd) ?? undefined,
+    updatedTs: toIsoTimestamp(risk?.updated_ts),
+  }
+
+  const strategyParamsRaw = state?.strategy_params && typeof state.strategy_params === 'object' ? state.strategy_params : {}
+  const strategyParams: TraderStrategyParamsSnapshot = {}
+  for (const [k, v] of Object.entries(strategyParamsRaw)) {
+    if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean' || v === null) {
+      strategyParams[String(k)] = v as any
+    }
+  }
+
+  const ai = state?.ai_strategist && typeof state.ai_strategist === 'object' ? state.ai_strategist : {}
+  const aiState = ai?.state && typeof ai.state === 'object' ? ai.state : {}
+  const aiStrategist: TraderAiStrategistSnapshot = {
+    enabled: Boolean(ai?.enabled),
+    provider: pickFirstString(ai?.provider),
+    model: pickFirstString(ai?.model),
+    state: {
+      lastRunTs: toIsoTimestamp(aiState?.last_run_ts ?? aiState?.lastRunTs),
+      lastChange: toIsoTimestamp(aiState?.last_change ?? aiState?.lastChange),
+    },
   }
 
   let lastError: string | null = null
@@ -370,8 +455,14 @@ export function readTraderStatusSnapshot(): TraderStatusSnapshot {
     cashUsd,
     openPositions,
     openOrdersCount,
+    openOrders,
+    risk: riskSnapshot,
+    strategyParams,
+    aiStrategist,
     products: Array.from(inferredProducts).sort(),
-    lastRunTs: toIsoTimestamp(state?.ts ?? state?.timestamp ?? state?.lastRunTs ?? state?.last_run_ts ?? state?.updatedAt) || new Date(stateStat.mtimeMs).toISOString(),
+    lastRunTs:
+      toIsoTimestamp(state?.ts ?? state?.timestamp ?? state?.lastRunTs ?? state?.last_run_ts ?? state?.updatedAt) ||
+      new Date(stateStat.mtimeMs).toISOString(),
     lastError,
     killSwitchEnabled: fs.existsSync(killSwitchPath),
   }
@@ -380,19 +471,28 @@ export function readTraderStatusSnapshot(): TraderStatusSnapshot {
 export function parseTradeRow(raw: any): TraderTradeRow | null {
   if (!raw || typeof raw !== 'object') return null
 
+  // Contract: trades.jsonl contains type="closed_trade" entries.
+  // If type is present and not closed_trade, ignore the line.
+  const rawType = asTrimmedString((raw as any)?.type)
+  if (rawType && rawType.toLowerCase() !== 'closed_trade') return null
+
   const product = sanitizeProduct(raw?.product ?? raw?.symbol ?? raw?.instrument ?? raw?.market)
   if (!product) return null
 
   const reason = pickFirstString(raw?.reason, raw?.note, raw?.signal, raw?.strategyReason, raw?.meta?.reason)
 
   return {
-    ts: parseTradeTimestamp(raw),
+    id: pickFirstString(raw?.id, raw?.trade_id, raw?.tradeId),
+    type: 'closed_trade',
     product,
     side: normalizeTradeSide(raw),
-    qty: pickFirstNumber(raw?.qty, raw?.quantity, raw?.size, raw?.amount),
-    price: pickFirstNumber(raw?.price, raw?.fillPrice, raw?.fill_price, raw?.avgFillPrice),
-    fees: pickFirstNumber(raw?.fees, raw?.fee, raw?.feesUsd, raw?.fees_usd),
-    pnlUsd: pickFirstNumber(raw?.pnlUsd, raw?.pnl_usd, raw?.realizedPnlUsd, raw?.realized_pnl_usd, raw?.pnl),
+    qtyBase: pickFirstNumber(raw?.qty_base, raw?.qty, raw?.quantity, raw?.size, raw?.amount),
+    entryPrice: pickFirstNumber(raw?.entry_price, raw?.entryPrice),
+    exitPrice: pickFirstNumber(raw?.exit_price, raw?.exitPrice),
+    pnlUsd: pickFirstNumber(raw?.pnl_usd, raw?.pnlUsd, raw?.realized_pnl_usd, raw?.realizedPnlUsd, raw?.pnl),
+    pnlPct: pickFirstNumber(raw?.pnl_pct, raw?.pnlPct),
+    openTs: toIsoTimestamp(raw?.open_ts ?? raw?.openTs),
+    closeTs: toIsoTimestamp(raw?.close_ts ?? raw?.closeTs) || parseTradeTimestamp(raw),
     reason: reason ? redactSensitiveText(reason) : null,
   }
 }
@@ -468,7 +568,7 @@ export function tailJsonlRowsFromFile(filePath: string, limit: number, options?:
     }
   }
 
-  rows.reverse()
+  // We push from newest -> oldest, so keep it that way.
   return rows
 }
 

--- a/pages/api/trader/state.ts
+++ b/pages/api/trader/state.ts
@@ -1,0 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+// Alias for /api/trader/status with identical payload.
+// Preferred endpoint per docs: /api/trader/state.
+
+import handler from './status'
+
+export default async function stateHandler(req: NextApiRequest, res: NextApiResponse) {
+  return handler(req, res)
+}

--- a/pages/api/trader/status.ts
+++ b/pages/api/trader/status.ts
@@ -1,5 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import type { TraderMode, TraderOpenPosition, TraderStatusSnapshot } from '../../../lib/trader'
+import type {
+  TraderAiStrategistSnapshot,
+  TraderMode,
+  TraderOpenPosition,
+  TraderRiskSnapshot,
+  TraderStrategyParamsSnapshot,
+  TraderStatusSnapshot,
+} from '../../../lib/trader'
 
 type TraderStatusResponse =
   | {
@@ -9,6 +16,10 @@ type TraderStatusResponse =
       cashUsd: number | null
       openPositions: TraderOpenPosition[]
       openOrdersCount: number
+      openOrders: Array<{ id: string | null; product: string | null; side: string | null; qtyBase: number | null; status: string | null }>
+      risk: TraderRiskSnapshot
+      strategyParams: TraderStrategyParamsSnapshot
+      aiStrategist: TraderAiStrategistSnapshot
       products: string[]
       lastRunTs: string | null
       lastError: string | null
@@ -69,6 +80,10 @@ export async function buildTraderStatusResponse(
         cashUsd: snapshot.cashUsd,
         openPositions: snapshot.openPositions,
         openOrdersCount: snapshot.openOrdersCount,
+        openOrders: snapshot.openOrders,
+        risk: snapshot.risk,
+        strategyParams: snapshot.strategyParams,
+        aiStrategist: snapshot.aiStrategist,
         products: snapshot.products,
         lastRunTs: snapshot.lastRunTs,
         lastError: snapshot.lastError,

--- a/pages/api/trader/trades.ts
+++ b/pages/api/trader/trades.ts
@@ -60,7 +60,7 @@ export async function buildTraderTradesResponse(
   }
 
   try {
-    const limit = deps.normalizeTradesLimit(readQueryParam(request.query?.limit), 50, 500)
+    const limit = deps.normalizeTradesLimit(readQueryParam(request.query?.limit), 200, 500)
     return {
       statusCode: 200,
       body: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -185,6 +185,30 @@ type TraderOpenPosition = {
   unrealizedPnlUsd?: number
 }
 
+type TraderRiskSnapshot = {
+  drawdownHalt?: boolean
+  cooldownActive?: boolean
+  drawdownPct?: number
+  maxDrawdownSeenPct?: number
+  lossStreak?: number
+  dayId?: string
+  dayRealizedPnlUsd?: number
+  dayStartEquityUsd?: number
+  updatedTs?: string | null
+}
+
+type TraderStrategyParamsSnapshot = Record<string, string | number | boolean | null>
+
+type TraderAiStrategistSnapshot = {
+  enabled: boolean
+  provider: string | null
+  model: string | null
+  state: {
+    lastRunTs: string | null
+    lastChange: string | null
+  }
+}
+
 type TraderStatusData =
   | {
       available: true
@@ -193,6 +217,10 @@ type TraderStatusData =
       cashUsd: number | null
       openPositions: TraderOpenPosition[]
       openOrdersCount: number
+      openOrders: Array<{ id: string | null; product: string | null; side: string | null; qtyBase: number | null; status: string | null }>
+      risk: TraderRiskSnapshot
+      strategyParams: TraderStrategyParamsSnapshot
+      aiStrategist: TraderAiStrategistSnapshot
       products: string[]
       lastRunTs: string | null
       lastError: string | null
@@ -206,13 +234,17 @@ type TraderStatusData =
     }
 
 type TraderTradeRow = {
-  ts: string | null
+  id: string | null
+  type: 'closed_trade'
   product: string
   side: string | null
-  qty: number | null
-  price: number | null
-  fees: number | null
+  qtyBase: number | null
+  entryPrice: number | null
+  exitPrice: number | null
   pnlUsd: number | null
+  pnlPct: number | null
+  openTs: string | null
+  closeTs: string | null
   reason: string | null
 }
 
@@ -360,7 +392,7 @@ export default function Home() {
   const [projectsData, setProjectsData] = useState<ProjectsSummaryData | null>(null)
   const [traderStatus, setTraderStatus] = useState<TraderStatusData | null>(null)
   const [traderTrades, setTraderTrades] = useState<TraderTradesData | null>(null)
-  const [traderTradesLimit, setTraderTradesLimit] = useState<number>(50)
+  const [traderTradesLimit, setTraderTradesLimit] = useState<number>(200)
 
   const [loading, setLoading] = useState(true)
 
@@ -398,7 +430,7 @@ export default function Home() {
         safeFetchJson('/api/swarm/status'),
         safeFetchJson('/api/cron/list'),
         safeFetchJson('/api/projects/summary'),
-        safeFetchJson('/api/trader/status'),
+        safeFetchJson('/api/trader/state'),
         safeFetchJson(`/api/trader/trades?limit=${encodeURIComponent(String(traderTradesLimit))}`),
       ])
 
@@ -626,6 +658,7 @@ export default function Home() {
       return {
         winRate: null as number | null,
         totalPnl: null as number | null,
+        avgPnl: null as number | null,
         maxDrawdown: null as number | null,
         tradesPerDay: null as number | null,
       }
@@ -643,7 +676,7 @@ export default function Home() {
       }
     }
 
-    const rowsSorted = [...traderTrades.rows].sort((a, b) => Date.parse(a.ts || '') - Date.parse(b.ts || ''))
+    const rowsSorted = [...traderTrades.rows].sort((a, b) => Date.parse(a.closeTs || '') - Date.parse(b.closeTs || ''))
     let runningPnl = 0
     let peak = 0
     let maxDrawdown = 0
@@ -656,7 +689,7 @@ export default function Home() {
     }
 
     const timestamps = traderTrades.rows
-      .map((row) => Date.parse(row.ts || ''))
+      .map((row) => Date.parse(row.closeTs || ''))
       .filter((ms) => Number.isFinite(ms))
       .sort((a, b) => a - b)
     let tradesPerDay: number | null = null
@@ -670,6 +703,7 @@ export default function Home() {
     return {
       winRate: pnlSamples > 0 ? wins / pnlSamples : null,
       totalPnl,
+      avgPnl: pnlSamples > 0 ? totalPnl / pnlSamples : null,
       maxDrawdown,
       tradesPerDay,
     }
@@ -945,6 +979,52 @@ export default function Home() {
             )}
           </div>
 
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+            <div className="card">
+              <div className="text-white font-semibold">Risk</div>
+              <div className="mt-2 text-sm space-y-1">
+                <div className="flex items-center justify-between"><span className="text-slate-400">drawdown halt</span><span className={traderStatus.risk.drawdownHalt ? 'text-rose-200' : 'text-emerald-200'}>{traderStatus.risk.drawdownHalt ? 'yes' : 'no'}</span></div>
+                <div className="flex items-center justify-between"><span className="text-slate-400">cooldown active</span><span className={traderStatus.risk.cooldownActive ? 'text-rose-200' : 'text-emerald-200'}>{traderStatus.risk.cooldownActive ? 'yes' : 'no'}</span></div>
+                <div className="flex items-center justify-between"><span className="text-slate-400">drawdown</span><span className="text-slate-200">{typeof traderStatus.risk.drawdownPct === 'number' ? `${fmtNumber(traderStatus.risk.drawdownPct * 100, 2)}%` : 'n/a'}</span></div>
+                <div className="flex items-center justify-between"><span className="text-slate-400">max drawdown seen</span><span className="text-slate-200">{typeof traderStatus.risk.maxDrawdownSeenPct === 'number' ? `${fmtNumber(traderStatus.risk.maxDrawdownSeenPct * 100, 2)}%` : 'n/a'}</span></div>
+                <div className="flex items-center justify-between"><span className="text-slate-400">loss streak</span><span className="text-slate-200">{typeof traderStatus.risk.lossStreak === 'number' ? traderStatus.risk.lossStreak : 'n/a'}</span></div>
+                <div className="flex items-center justify-between"><span className="text-slate-400">day realized pnl</span><span className="text-slate-200">{fmtUsd(traderStatus.risk.dayRealizedPnlUsd)}</span></div>
+              </div>
+            </div>
+
+            <div className="card">
+              <div className="text-white font-semibold">Strategy + AI strategist</div>
+              <div className="text-slate-400 text-xs mt-1">From state.json (strategy_params, ai_strategist)</div>
+
+              <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3">
+                <div className="bg-slate-950/30 border border-slate-800 rounded-lg p-3">
+                  <div className="text-slate-400 text-xs">AI strategist</div>
+                  <div className="text-slate-200 mt-1">{traderStatus.aiStrategist.enabled ? 'enabled' : 'disabled'}</div>
+                  <div className="text-slate-500 text-xs mt-1">{traderStatus.aiStrategist.provider || 'provider?'} • {traderStatus.aiStrategist.model || 'model?'}</div>
+                  <div className="text-slate-500 text-xs mt-1">last run: {isoToHuman(traderStatus.aiStrategist.state.lastRunTs)}</div>
+                </div>
+
+                <div className="bg-slate-950/30 border border-slate-800 rounded-lg p-3">
+                  <div className="text-slate-400 text-xs">Strategy params</div>
+                  <div className="mt-2 space-y-1 text-xs">
+                    {Object.keys(traderStatus.strategyParams || {}).length === 0 ? (
+                      <div className="text-slate-500">n/a</div>
+                    ) : (
+                      Object.entries(traderStatus.strategyParams)
+                        .slice(0, 14)
+                        .map(([k, v]) => (
+                          <div key={k} className="flex items-center justify-between gap-3">
+                            <span className="text-slate-500 truncate">{k}</span>
+                            <span className="text-slate-200">{String(v)}</span>
+                          </div>
+                        ))
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
           <div className="card p-0 overflow-hidden">
             <div className="px-4 py-3 border-b border-slate-800">
               <div className="text-white font-semibold">Open Positions ({traderStatus.openPositions.length})</div>
@@ -993,6 +1073,12 @@ export default function Home() {
               </div>
             </div>
             <div className="card">
+              <div className="text-slate-400 text-xs">Avg PnL (recent)</div>
+              <div className={`text-2xl font-bold mt-2 ${typeof traderStats.avgPnl === 'number' && traderStats.avgPnl < 0 ? 'text-rose-200' : 'text-emerald-200'}`}>
+                {fmtUsd(traderStats.avgPnl)}
+              </div>
+            </div>
+            <div className="card">
               <div className="text-slate-400 text-xs">Max drawdown (recent)</div>
               <div className="text-2xl font-bold mt-2 text-rose-200">{fmtUsd(traderStats.maxDrawdown)}</div>
             </div>
@@ -1022,7 +1108,7 @@ export default function Home() {
               Rows
               <select
                 value={traderTradesLimit}
-                onChange={(e) => setTraderTradesLimit(Number(e.target.value) || 50)}
+                onChange={(e) => setTraderTradesLimit(Number(e.target.value) || 200)}
                 className="bg-slate-900 border border-slate-700 text-slate-200 text-xs rounded px-2 py-1"
               >
                 {TRADER_TRADE_LIMIT_OPTIONS.map((n) => (
@@ -1040,29 +1126,33 @@ export default function Home() {
               <table className="min-w-[980px] w-full text-xs">
                 <thead className="bg-slate-900/70">
                   <tr className="text-slate-400">
-                    <th className="text-left px-3 py-2 font-medium">ts</th>
+                    <th className="text-left px-3 py-2 font-medium">close</th>
                     <th className="text-left px-3 py-2 font-medium">product</th>
                     <th className="text-left px-3 py-2 font-medium">side</th>
-                    <th className="text-left px-3 py-2 font-medium">qty</th>
-                    <th className="text-left px-3 py-2 font-medium">price</th>
-                    <th className="text-left px-3 py-2 font-medium">fees</th>
-                    <th className="text-left px-3 py-2 font-medium">pnl</th>
+                    <th className="text-left px-3 py-2 font-medium">qty (base)</th>
+                    <th className="text-left px-3 py-2 font-medium">entry</th>
+                    <th className="text-left px-3 py-2 font-medium">exit</th>
+                    <th className="text-left px-3 py-2 font-medium">pnl $</th>
+                    <th className="text-left px-3 py-2 font-medium">pnl %</th>
                     <th className="text-left px-3 py-2 font-medium">reason</th>
                   </tr>
                 </thead>
                 <tbody>
                   {traderRows.map((row, idx) => (
-                    <tr key={`${row.ts || 'na'}-${row.product}-${idx}`} className="border-t border-slate-800">
-                      <td className="px-3 py-2 text-slate-300 whitespace-nowrap">{isoToHuman(row.ts)}</td>
+                    <tr key={`${row.closeTs || 'na'}-${row.product}-${row.id || idx}`} className="border-t border-slate-800">
+                      <td className="px-3 py-2 text-slate-300 whitespace-nowrap">{isoToHuman(row.closeTs)}</td>
                       <td className="px-3 py-2 text-slate-100">{row.product}</td>
                       <td className="px-3 py-2 text-slate-300">{row.side || 'n/a'}</td>
-                      <td className="px-3 py-2 text-slate-300">{fmtNumber(row.qty)}</td>
-                      <td className="px-3 py-2 text-slate-300">{fmtUsd(row.price)}</td>
-                      <td className="px-3 py-2 text-slate-300">{fmtUsd(row.fees)}</td>
+                      <td className="px-3 py-2 text-slate-300">{fmtNumber(row.qtyBase)}</td>
+                      <td className="px-3 py-2 text-slate-300">{fmtUsd(row.entryPrice)}</td>
+                      <td className="px-3 py-2 text-slate-300">{fmtUsd(row.exitPrice)}</td>
                       <td className={`px-3 py-2 ${typeof row.pnlUsd === 'number' && row.pnlUsd < 0 ? 'text-rose-200' : 'text-emerald-200'}`}>
                         {fmtUsd(row.pnlUsd)}
                       </td>
-                      <td className="px-3 py-2 text-slate-300 max-w-[320px] truncate" title={row.reason || ''}>
+                      <td className={`px-3 py-2 ${typeof row.pnlPct === 'number' && row.pnlPct < 0 ? 'text-rose-200' : 'text-emerald-200'}`}>
+                        {typeof row.pnlPct === 'number' ? `${fmtNumber(row.pnlPct * 100, 2)}%` : 'n/a'}
+                      </td>
+                      <td className="px-3 py-2 text-slate-300 max-w-[360px] truncate" title={row.reason || ''}>
                         {row.reason || 'n/a'}
                       </td>
                     </tr>

--- a/tests/trader-lib.test.ts
+++ b/tests/trader-lib.test.ts
@@ -25,20 +25,24 @@ test('allowlist only accepts fixed trader file paths', () => {
   assert.equal(isAllowedTraderPath('/tmp/unrelated.json'), false)
 })
 
-test('tailJsonlRowsFromFile returns latest parsed rows in chronological order', () => {
+test('tailJsonlRowsFromFile returns latest parsed rows newest-first', () => {
   const tmp = path.join(os.tmpdir(), `mission-center-trades-${Date.now()}.jsonl`)
   const lines: string[] = []
 
   for (let i = 1; i <= 40; i += 1) {
     lines.push(
       JSON.stringify({
-        ts: 1_700_000_000 + i,
+        type: 'closed_trade',
+        id: `t-${i}`,
+        open_ts: 1_700_000_000 + i - 10,
+        close_ts: 1_700_000_000 + i,
         product: i % 2 === 0 ? 'BTC-USD' : 'ETH-USD',
         side: i % 2 === 0 ? 'buy' : 'sell',
-        qty: i / 10,
-        price: 100 + i,
-        fees: 0.01 * i,
-        pnlUsd: i - 20,
+        qty_base: i / 10,
+        entry_price: 100 + i,
+        exit_price: 101 + i,
+        pnl_usd: i - 20,
+        pnl_pct: (i - 20) / 100,
         reason: `signal-${i}`,
       }),
     )
@@ -46,14 +50,14 @@ test('tailJsonlRowsFromFile returns latest parsed rows in chronological order', 
 
   // Malformed lines should be skipped without failing the endpoint.
   lines.push('not-json')
-  lines.push(JSON.stringify({ ts: 1_800_000_000, side: 'buy' }))
+  lines.push(JSON.stringify({ type: 'closed_trade', close_ts: 1_800_000_000, side: 'buy' }))
 
   fs.writeFileSync(tmp, lines.join('\n') + '\n', 'utf-8')
 
   const rows = tailJsonlRowsFromFile(tmp, 5, { initialBytes: 64, maxBytes: 16 * 1024, maxPasses: 8 })
   assert.equal(rows.length, 5)
-  assert.equal(rows[0].reason, 'signal-36')
-  assert.equal(rows[4].reason, 'signal-40')
+  assert.equal(rows[0].reason, 'signal-40')
+  assert.equal(rows[4].reason, 'signal-36')
   assert.equal(rows[0].product, 'BTC-USD')
   assert.equal(rows[1].product, 'ETH-USD')
 
@@ -69,18 +73,23 @@ test('normalizeTradesLimit enforces default and max bounds', () => {
 
 test('parseTradeRow redacts reason text and normalizes fields', () => {
   const row = parseTradeRow({
-    ts: 1_700_000_000,
+    type: 'closed_trade',
+    id: 't-1',
+    open_ts: 1_700_000_000,
+    close_ts: 1_700_000_100,
     product: 'BTC-USD',
     side: 'BUY',
-    qty: '0.2',
-    price: '100.12',
-    fee: 0.5,
+    qty_base: '0.2',
+    entry_price: '100.12',
+    exit_price: '101.12',
     pnl_usd: -1.25,
+    pnl_pct: -0.0125,
     reason: 'OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz12345',
   })
 
   assert.ok(row)
   assert.equal(row?.side, 'buy')
-  assert.equal(row?.qty, 0.2)
+  assert.equal(row?.qtyBase, 0.2)
+  assert.equal(row?.pnlPct, -0.0125)
   assert.equal(row?.reason?.includes('sk-abcdefghijklmnopqrstuvwxyz12345'), false)
 })


### PR DESCRIPTION
## Why
You specified an exact local trader schema: `state.json` fields (portfolio/risk/strategy_params/ai_strategist) and `trades.jsonl` lines with `type="closed_trade"` and pnl_usd/pnl_pct. The current Trader view needed to match that precisely.

## What
- Trader status now surfaces the requested fields from `state.json`:
  - equity/cash, positions + open_meta
  - open_orders (count + summary)
  - risk flags
  - strategy_params
  - ai_strategist (enabled/provider/model/state)
- Trades endpoint now follows your contract:
  - reads `trades.jsonl`
  - filters to `type=closed_trade` when present
  - returns last N (default **200**, max 500) **newest-first**
  - returns pnl_usd + pnl_pct + entry/exit + open/close timestamps
- Added endpoint alias: `GET /api/trader/state` (same payload as /api/trader/status).
- Updated Trader UI to display:
  - risk flags + strategy params + AI strategist status
  - trade table with pnl $ and pnl %
  - metrics include avg PnL
- Updated docs + tests to match the contract.

## Security
- Still whitelisted reads only under `autonomous-crypto-trader/`
- Redaction stays in place for any surfaced text

## Test plan
- `npm test`
- `npm run build`
- Manual: open Trader tab; verify risk/strategy/ai strategist fields show from state.json